### PR TITLE
Change pushState to replaceState

### DIFF
--- a/js/contentScript.js
+++ b/js/contentScript.js
@@ -1,7 +1,7 @@
 window.onload = () => {
   const asinElement = document.querySelector('#ASIN, input[name="idx.asin"], input[name="ASIN.0"]')
   if (asinElement) {
-    window.history.pushState(
+    window.history.replaceState(
       {},
       '',
       `/dp/${asinElement.value}`


### PR DESCRIPTION
便利なChrome拡張機能ありがとうございます！
利用していて気づいたのですが、URLの書き換え後にブラウザバックすると長いURLのページに戻ってしまいます。

用途的には短いURLを追加するより、置き換えたほうが便利かと思いますのでプルリクさせていただきます。
ご検討いただければ嬉しいです！