### PR TITLE
Check `asinElement.value` exists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ const asinElement = document.querySelector(
   '#ASIN, input[name="idx.asin"], input[name="ASIN.0"], input[name="titleID"]'
 ) as HTMLInputElement;
 
-if (asinElement) {
+if (asinElement && asinElement.value) {
   replaceState(`/dp/${asinElement.value}`);
 } else {
   const href = window.location.href;


### PR DESCRIPTION
I noticed that on Audible product pages, `asinElement.value` becomes an empty string and is not replaced with the correct URL.
For example: https://www.amazon.co.jp/dp/B0CQPKZMM6
<img width="1116" height="133" alt="2026-03-05 at 14 00 34" src="https://github.com/user-attachments/assets/c7a22545-068d-4a76-a19d-c097b3e4df28" />

This issue can be resolved by modifying the `if` condition.
